### PR TITLE
Update Flake8 to Version 4.0.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - pycodestyle
     - pyflakes
     - importlib-metadata
-    - setuptools >=30.0.0
+    - setuptools
 test:
   imports:
     - flake8

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,12 +21,13 @@ requirements:
     - python
     - pip
     - pytest-runner
+    - wheel
     - setuptools >=30.0.0
   run:
     - python >=3.6
     - mccabe >=0.6.0,<0.7.0
-    - pycodestyle >=2.7.0,<2.8.0
-    - pyflakes >=2.3.0,<2.4.0
+    - pycodestyle >=2.8.0,<2.9.0
+    - pyflakes >=2.4.0,<2.5.0
     - importlib-metadata  # [py<38]
     - setuptools >=30.0.0
 test:
@@ -44,7 +45,8 @@ test:
   commands:
     - flake8 --ignore=D203,W503,E203 src/flake8 tests/integration tests/unit setup.py  # [unix]
     - flake8 --ignore=D203,W503,E203 src\\flake8 tests\\integration tests\\unit setup.py  # [win]
-    - pip check
+    # the pip test does not work at this time
+    # - pip check
 
 about:
   home: http://flake8.pycqa.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.9.2" %}
+{% set version = "4.0.1" %}
 
 package:
   name: flake8
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/f/flake8/flake8-{{ version }}.tar.gz
-  sha256: 07528381786f2a6237b061f6e96610a4167b226cb926e2aa2b6b1d78057c576b
+  sha256: 806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,6 @@ requirements:
     - pycodestyle
     - pyflakes
     - importlib-metadata
-    - setuptools
 test:
   imports:
     - flake8

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,6 +9,7 @@ source:
   sha256: 806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d
 
 build:
+  skip: True  # [py<37]
   number: 0
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps -vv
@@ -17,7 +18,7 @@ build:
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
     - pytest-runner
     - setuptools >=30.0.0
@@ -31,6 +32,9 @@ requirements:
 test:
   imports:
     - flake8
+  requires:
+    - pip
+    - python <3.10
   source_files:
     - src/flake8
     - tests/integration
@@ -40,6 +44,7 @@ test:
   commands:
     - flake8 --ignore=D203,W503,E203 src/flake8 tests/integration tests/unit setup.py  # [unix]
     - flake8 --ignore=D203,W503,E203 src\\flake8 tests\\integration tests\\unit setup.py  # [win]
+    - pip check
 
 about:
   home: http://flake8.pycqa.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,9 +26,9 @@ requirements:
   run:
     - python >=3.6
     - mccabe >=0.6.0,<0.7.0
-    - pycodestyle >=2.8.0,<2.9.0
-    - pyflakes >=2.4.0,<2.5.0
-    - importlib-metadata  # [py<38]
+    - pycodestyle
+    - pyflakes
+    - importlib-metadata
     - setuptools >=30.0.0
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,7 +46,7 @@ test:
     - flake8 --ignore=D203,W503,E203 src/flake8 tests/integration tests/unit setup.py  # [unix]
     - flake8 --ignore=D203,W503,E203 src\\flake8 tests\\integration tests\\unit setup.py  # [win]
     # the pip test does not work at this time
-    # - pip check
+    - pip check
 
 about:
   home: http://flake8.pycqa.org/


### PR DESCRIPTION
1. check the upstream
https://gitlab.com/pycqa/flake8

2. check the pinnings
https://gitlab.com/pycqa/flake8/-/blob/master/tox.ini
https://gitlab.com/pycqa/flake8/-/blob/master/setup.cfg

3. check changelogs
The change log document is missing so instead, the release notes were verified.

https://gitlab.com/pycqa/flake8/-/tree/master/docs/source/release-notes

https://gitlab.com/pycqa/flake8/-/blob/master/docs/source/internal/releases.rst

There was very limited information on version `4.0.1`
Did not find any evidence of breaking changes.

We will have to rely on additional research

4. additional research
https://github.com/conda-forge/flake8-feedstock/issues/52

There is only one known issue at the time of the review. 
The issue is related to `importlib-metadata` version constrains

The issue seems to affect versions newer than 4.3, however it might be wise to keep an eye on that issue. 

5. verify dev_url
     https://gitlab.com/pycqa/flake8
6. verify doc_url
     http://flake8.pycqa.org/
7. added pip to the test section as a comment
8. verify the test section
9. additional tests

In order to test the `flake8` package version `4.0.1` the following command was used:
`conda build flake8-feedstock --test` 
The test result was the following:
`All tests passed`
