### PR TITLE
Rebuild `flake8` version `4.0.1` to build `python-lsp-server`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - setuptools >=30.0.0
   run:
     - python >=3.6
-    - mccabe >=0.6.0,<0.7.0
+    - mccabe >=0.6.0,<0.8.0
     - pycodestyle >=2.8.0,<2.9.0
     - pyflakes >=2.4.0,<2.5.0
     - importlib-metadata <4.3  # [py<38]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ build:
 
 requirements:
   host:
-    - python >=3.6
+    - python >=3.6 
     - pip
     - wheel
     - setuptools >=30.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,13 +17,13 @@ build:
 
 requirements:
   host:
-    - python >=3.7
+    - python >=3.6
     - pip
     - pytest-runner
     - wheel
     - setuptools >=30.0.0
   run:
-    - python >=3.7
+    - python >=3.6
     - mccabe >=0.6.0,<0.7.0
     - pycodestyle >=2.8.0,<2.9.0
     - pyflakes >=2.4.0,<2.5.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,6 @@ source:
   sha256: 806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d
 
 build:
-  skip: True  # [py<37]
   number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps -vv
@@ -18,16 +17,16 @@ build:
 
 requirements:
   host:
-    - python
+    - python >=3.7
     - pip
     - pytest-runner
     - wheel
     - setuptools >=30.0.0
   run:
-    - python >=3.6
-    - mccabe >=0.6.0,<0.7.0
-    - pycodestyle
-    - pyflakes
+    - python >=3.7
+    - mccabe >=0.6.0,<0.7.0  # [py<38] 
+    - pycodestyle >=2.8.0,<2.9.0
+    - pyflakes >=2.4.0,<2.5.0
     - importlib-metadata <4.3
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   skip: True  # [py<37]
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
@@ -28,7 +28,7 @@ requirements:
     - mccabe >=0.6.0,<0.7.0
     - pycodestyle
     - pyflakes
-    - importlib-metadata
+    - importlib-metadata <4.3
 test:
   imports:
     - flake8
@@ -48,12 +48,12 @@ test:
     - pip check
 
 about:
-  home: http://flake8.pycqa.org/
+  home: https://flake8.pycqa.org/
   license: MIT
   license_family: MIT
   license_file: LICENSE
   summary: Your Tool For Style Guide Enforcement
-  doc_url: http://flake8.pycqa.org/
+  doc_url: https://flake8.pycqa.org/
   dev_url: https://gitlab.com/pycqa/flake8
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,10 +24,10 @@ requirements:
     - setuptools >=30.0.0
   run:
     - python >=3.7
-    - mccabe >=0.6.0,<0.7.0  # [py<38] 
+    - mccabe >=0.6.0,<0.7.0
     - pycodestyle >=2.8.0,<2.9.0
     - pyflakes >=2.4.0,<2.5.0
-    - importlib-metadata <4.3
+    - importlib-metadata <4.3  # [py<38]
 test:
   imports:
     - flake8


### PR DESCRIPTION
Rebuild `flake8` version `4.0.1` to include the correct version of `importlib-metadata`, needed to rebuild `python-lsp-server`

--

`flake8` version `4.0.1`
1. - [x] Check the upstream
    https://gitlab.com/pycqa/flake8/tree/4.0.1

2. - [x] Check the pinnings

    `pycodestyle>=2.8.0,<2.9.0`
    https://gitlab.com/pycqa/flake8/-/blob/4.0.1/setup.cfg#L43

    `pyflakes>=2.4.0,<2.5.0`
     https://gitlab.com/pycqa/flake8/-/blob/4.0.1/setup.cfg#L44

    `importlib-metadata<4.3`
    https://gitlab.com/pycqa/flake8/-/blob/4.0.1/setup.cfg#L45

3. - [x] Check the changelogs

    https://gitlab.com/pycqa/flake8/-/tree/4.0.1/docs/source/release-notes

4. - [x] Additional research
    https://github.com/conda-forge/flake8-feedstock/issues

    currently there are no significant open issues mentined in the upstream at the time of the review

5. - [x] Verify the `dev_url`
    https://gitlab.com/pycqa/flake8

6. - [x] Verify the `doc_url`
    http://flake8.pycqa.org/

7. - [x] License is `spdx` compliant
    MIT

8. - [x] License family is present
    MIT
9. - [x] Verify that the `build_number` is correct

    The build number has been increased by one

10. - [x] Verify if the package needs `setuptools`
11. - [x] Verify if the package needs `wheel`
12. - [x] `pip` in the test section
13. - [x] Veriy the test section
14. - [x] Verify if the package is `architecture specific` or `Noarch`

    The package is a rebuild due to this fact we will have to keep the package as a `noarch` package.
    While we are no longer building `noarch` packages, in this particular case we will have to make an exception.

15. - [x] Verify that private modules are not mentioned on the recipe For example: (_private_module)

Results:
-


Based on the research findings and the results we can conclude
that it is safe to rebuild `flake8` version `4.0.1`

