### PR TITLE
4.0.1 rebuild

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
-channel:
+channels:
   melody_org: swagger-ui-bundle-update

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,6 @@
 channels:
   melody_org: swagger-ui-bundle-update
+build_parameters:
+  - "--suppress-variables"
+  - "--error-overlinking"
+  - "--error-overdepending"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channel:
+  melody_org: swagger-ui-bundle-update

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,6 @@ requirements:
   host:
     - python
     - pip
-    - pytest-runner
     - wheel
     - setuptools >=30.0.0
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,6 +55,7 @@ about:
     mccabe, and third-party plugins to check the style and quality of
     some python code.
   doc_url: https://flake8.pycqa.org/
+  doc_source_url: https://github.com/PyCQA/flake8/blob/main/docs/source/index.rst
   dev_url: https://gitlab.com/pycqa/flake8
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d
 
 build:
-  number: 1
+  number: 2
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - mccabe >=0.6.0,<0.7.0
     - pycodestyle >=2.8.0,<2.9.0
     - pyflakes >=2.4.0,<2.5.0
-    - importlib-metadata
+    - importlib-metadata <4.3
 test:
   imports:
     - flake8

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
   run:
     - python >=3.6
     # mccabe 0.7.0 is a noarch python package now and it hasn't broken changes for flake8
-    - mccabe >=0.6.0,<0.8.0
+    - mccabe >=0.6.0,<0.7.0
     - pycodestyle >=2.8.0,<2.9.0
     - pyflakes >=2.4.0,<2.5.0
     - importlib-metadata

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,8 +9,7 @@ source:
   sha256: 806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d
 
 build:
-  skip: True  # [py<37]
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
@@ -25,16 +24,16 @@ requirements:
     - setuptools >=30.0.0
   run:
     - python >=3.6
-    - mccabe >=0.6.0,<0.7.0
-    - pycodestyle
-    - pyflakes
+    # mccabe 0.7.0 is a noarch python package now and it hasn't broken changes for flake8
+    - mccabe >=0.6.0,<0.8.0
+    - pycodestyle >=2.8.0,<2.9.0
+    - pyflakes >=2.4.0,<2.5.0
     - importlib-metadata
 test:
   imports:
     - flake8
   requires:
     - pip
-    - python <3.10
   source_files:
     - src/flake8
     - tests/integration
@@ -44,8 +43,9 @@ test:
   commands:
     - flake8 --ignore=D203,W503,E203 src/flake8 tests/integration tests/unit setup.py  # [unix]
     - flake8 --ignore=D203,W503,E203 src\\flake8 tests\\integration tests\\unit setup.py  # [win]
-    # the pip test does not work at this time
-    - pip check
+    # 2022/03/24: the pip test does not work at this time
+    # Enable it when mccabe bump a verion number
+    #- pip check
 
 about:
   home: http://flake8.pycqa.org/
@@ -53,7 +53,7 @@ about:
   license_family: MIT
   license_file: LICENSE
   summary: Your Tool For Style Guide Enforcement
-  doc_url: http://flake8.pycqa.org/
+  doc_url: https://flake8.pycqa.org/
   dev_url: https://gitlab.com/pycqa/flake8
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,6 @@ requirements:
     - setuptools >=30.0.0
   run:
     - python
-    # mccabe 0.7.0 is a noarch python package now and it hasn't broken changes for flake8
     - mccabe >=0.6.0,<0.7.0
     - pycodestyle >=2.8.0,<2.9.0
     - pyflakes >=2.4.0,<2.5.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,6 @@ source:
 
 build:
   number: 2
-  noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
     - flake8 = flake8.main.cli:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,9 +42,7 @@ test:
   commands:
     - flake8 --ignore=D203,W503,E203 src/flake8 tests/integration tests/unit setup.py  # [unix]
     - flake8 --ignore=D203,W503,E203 src\\flake8 tests\\integration tests\\unit setup.py  # [win]
-    # 2022/03/24: the pip test does not work at this time
-    # Enable it when mccabe bump a verion number
-    #- pip check
+    - pip check
 
 about:
   home: http://flake8.pycqa.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   number: 2
-  skip: true  # [py<37]
+  noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
     - flake8 = flake8.main.cli:main
@@ -26,7 +26,7 @@ requirements:
     - mccabe >=0.6.0,<0.7.0
     - pycodestyle >=2.8.0,<2.9.0
     - pyflakes >=2.4.0,<2.5.0
-    - importlib-metadata <4.3
+    - importlib-metadata
 test:
   imports:
     - flake8

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - mccabe >=0.6.0,<0.7.0
     - pycodestyle >=2.8.0,<2.9.0
     - pyflakes >=2.4.0,<2.5.0
-    - importlib-metadata
+    - importlib-metadata  # [py<38]
 test:
   imports:
     - flake8

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,10 +44,11 @@ test:
     - pip check
 
 about:
-  home: http://flake8.pycqa.org/
+  home: https://flake8.pycqa.org/
   license: MIT
   license_family: MIT
   license_file: LICENSE
+  license_url: https://github.com/PyCQA/flake8/blob/main/LICENSE
   summary: Your Tool For Style Guide Enforcement
   doc_url: https://flake8.pycqa.org/
   dev_url: https://gitlab.com/pycqa/flake8

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,6 +50,10 @@ about:
   license_file: LICENSE
   license_url: https://github.com/PyCQA/flake8/blob/main/LICENSE
   summary: Your Tool For Style Guide Enforcement
+  description: |
+    flake8 is a python tool that glues together pycodestyle, pyflakes,
+    mccabe, and third-party plugins to check the style and quality of
+    some python code.
   doc_url: https://flake8.pycqa.org/
   dev_url: https://gitlab.com/pycqa/flake8
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,7 @@ source:
 
 build:
   number: 2
+  skip: true  # [py<37]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
     - flake8 = flake8.main.cli:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - wheel
     - setuptools >=30.0.0
   run:
-    - python >=3.6
+    - python
     # mccabe 0.7.0 is a noarch python package now and it hasn't broken changes for flake8
     - mccabe >=0.6.0,<0.7.0
     - pycodestyle >=2.8.0,<2.9.0


### PR DESCRIPTION
`flake8 4.0.1` ---> `swagger-ui-bundle 0.0.9`

Jira issue: https://anaconda.atlassian.net/browse/PKG-114
Upstream repo: https://github.com/PyCQA/flake8/tree/4.0.1

Corrected `mccabe` pinnings to match [setup.cfg](https://github.com/PyCQA/flake8/blob/82b698e09996cdde5d473e234681d8380810d7a2/setup.cfg#L42)  in source repo.