### PR TITLE
PKG-5649

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-aggregate_branch: 3.12
-channels:
-  - https://staging.continuum.io/prefect/fs/pycodestyle-feedstock/pr6/01b7561

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,3 @@
 aggregate_branch: 3.12
+channels:
+  - https://staging.continuum.io/prefect/fs/pycodestyle-feedstock/pr6/01b7561

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "7.0.0" %}
+{% set version = "7.1.1" %}
 
 package:
   name: flake8
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/f/flake8/flake8-{{ version }}.tar.gz
-  sha256: 33f96621059e65eec474169085dc92bf26e7b2d47366b70be2f67ab80dc25132
+  sha256: 049d058491e228e03e67b390f311bbf88fce2dbaa8fa673e7aea87b7198b8d38
 
 build:
   number: 0
@@ -24,15 +24,21 @@ requirements:
   run:
     - python
     - mccabe >=0.7.0,<0.8.0
-    - pycodestyle >=2.11.0,<2.12.0
+    - pycodestyle >=2.12.0,<2.13.0
     - pyflakes >=3.2.0,<3.3.0
 
 test:
   imports:
     - flake8
+    - flake8.api
+    - flake8.formatting
+    - flake8.main
+    - flake8.options
+    - flake8.plugins
   requires:
     - pip
   commands:
+    # Cannot run pytest since source does not come with tests.
     - pip check
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ test:
   requires:
     - pip
   commands:
-    # Cannot run pytest since source does not come with tests.
+    # Cannot run pytest since PyPI distributed source does not come with tests.
     - pip check
 
 about:


### PR DESCRIPTION
flake8 7.1.1

**Destination channel:** defaults

### Links

- [PKG-5649](https://anaconda.atlassian.net/browse/PKG-5649) 
- [Upstream repository](https://github.com/PyCQA/flake8/tree/7.1.1)
- [Upstream changelog/diff](https://github.com/PyCQA/flake8/compare/7.0.0...7.1.1)
- Relevant dependency PRs:
  - AnacondaRecipes/pycodestyle-feedstock#6


[PKG-5649]: https://anaconda.atlassian.net/browse/PKG-5649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ